### PR TITLE
upgraded Elasticesearch curator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM gliderlabs/alpine:3.1
+FROM python:3.6-slim
 
-RUN apk add --update \
-    python \
-    python-dev \
-    py-pip
+RUN pip install --quiet elasticsearch-curator urllib3[secure]
+ADD ./docker-entrypoint.sh /
+ADD ./config/curator.yml /opt/curator/config/curator.yml
+ADD ./config/action.yml /opt/curator/config/action.yml
 
-RUN pip install elasticsearch-curator==3.0.0
-
-ENTRYPOINT ["curator"]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "/usr/local/bin/curator" ]

--- a/config/action.yml
+++ b/config/action.yml
@@ -1,0 +1,23 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+actions:
+  1:
+    action: delete_indices
+    description: "Delete selected indices"
+    options:
+      continue_if_exception: False
+      disable_action: False
+      ignore_empty_list: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude: False
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y-%m-%d'
+      unit: days
+      unit_count: 14
+      exclude: False

--- a/config/action.yml
+++ b/config/action.yml
@@ -19,5 +19,5 @@ actions:
       direction: older
       timestring: '%Y-%m-%d'
       unit: days
-      unit_count: 14
+      unit_count: 30
       exclude: False

--- a/config/curator.yml
+++ b/config/curator.yml
@@ -1,0 +1,24 @@
+---
+# Remember, leave a key empty if there is no value. None will be a string, not
+# a Python "NoneType"
+client:
+  hosts: [ '127.0.0.1' ]
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  aws_key:
+  aws_secret_key:
+  aws_region:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+if [ -z $ES_HOST ] ; then
+  echo "FATAL: environment variable ES_HOST missing." && exit 1
+fi
+
+if [ -z $ES_PORT ] ; then
+  echo "FATAL: environment variable ES_PORT missing." && exit 1
+fi
+
+if [ -z $ES_USER ] ; then
+  echo "FATAL: environment variable ES_USER missing." && exit 1
+fi
+
+if [ -z $ES_PASS ] ; then
+  echo "FATAL: environment variable ES_PASS missing." && exit 1
+fi
+
+KIBANA_INDEX=${KIBANA_INDEX:-.kibana}
+
+sed -i -e "s;^  hosts: \[ '127\.0\.0\.1' \];  hosts: [ '${ES_HOST}' ];" \
+       -e "s;^  port: 9200;  port: ${ES_PORT};" \
+       -e "s;^  http_auth:;  http_auth: '${ES_USER}:${ES_PASS}';" \
+       -e "s;^  use_ssl: False;  use_ssl: True;" \
+       /opt/curator/config/curator.yml
+
+# Add /usr/local/bin/curator as command if needed
+if [[ "$1" == -* ]]; then
+  set -- /usr/local/bin/curator "$@"
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,14 @@ if [ -z $ES_PASS ] ; then
   echo "FATAL: environment variable ES_PASS missing." && exit 1
 fi
 
+if [ -z $DELETE_UNIT ] ; then
+  echo "FATAL: environment variable DELETE_UNIT missing." && exit 1
+fi
+
+if [ -z $DELETE_UNIT_COUNT ] ; then
+  echo "FATAL: environment variable DELETE_UNIT_COUNT missing." && exit 1
+fi
+
 KIBANA_INDEX=${KIBANA_INDEX:-.kibana}
 
 sed -i -e "s;^  hosts: \[ '127\.0\.0\.1' \];  hosts: [ '${ES_HOST}' ];" \
@@ -24,6 +32,10 @@ sed -i -e "s;^  hosts: \[ '127\.0\.0\.1' \];  hosts: [ '${ES_HOST}' ];" \
        -e "s;^  http_auth:;  http_auth: '${ES_USER}:${ES_PASS}';" \
        -e "s;^  use_ssl: False;  use_ssl: True;" \
        /opt/curator/config/curator.yml
+
+sed -i -e "s;^      unit: days;      unit: ${DELETE_UNIT};" \
+       -e "s;^      unit_count: 30;      unit_count: ${DELETE_UNIT_COUNT};" \
+       /opt/curator/config/action.yml
 
 # Add /usr/local/bin/curator as command if needed
 if [[ "$1" == -* ]]; then


### PR DESCRIPTION
This PR goes towards https://github.com/giantswarm/giantswarm/issues/725. 

Running the curator on Leaseweb gives me this now. Since we throw away all the data in Elasticsearch and the Curator is only removing data which is 14 days old, there is nothing it is doing right now.

```
Sep 06 12:24:18 0b03b1b46b2f79d2 docker[3608]: 2016-09-06 12:24:18,968 INFO      Action #1: delete_indices
Sep 06 12:24:20 0b03b1b46b2f79d2 docker[3608]: 2016-09-06 12:24:20,176 INFO      Skipping action "delete_indices" due to empty list: <class 'curator.exceptions.NoIndices'>
Sep 06 12:24:20 0b03b1b46b2f79d2 docker[3608]: 2016-09-06 12:24:20,176 INFO      Action #1: completed
Sep 06 12:24:20 0b03b1b46b2f79d2 docker[3608]: 2016-09-06 12:24:20,176 INFO      Job completed.
```

See also https://github.com/giantswarm/releaseit/pull/551

RFR @giantswarm/team-positive 
