### PR TITLE
Index renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
             chmod +x ./architect
             ./architect version
       - run:
-          name: Install Python 3
-          command: sudo apt-get install -y python3
-      - run:
           name: Tests
           command: make test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
             chmod +x ./architect
             ./architect version
       - run:
+          name: Install Python 3
+          command: apt-get install -y python3
+      - run:
           name: Tests
           command: make test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             ./architect version
       - run:
           name: Install Python 3
-          command: apt-get install -y python3
+          command: sudo apt-get install -y python3
       - run:
           name: Tests
           command: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.7
 
-#RUN apk add --no-cache python3
+
 RUN apk add --no-cache python3 && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 
 test:
-	python3 --version
+	python --version
 	pip install elasticsearch freezegun
 	# Syntax check
-	python3 -m py_compile ./curator.py
-	python3 ./curator_test.py
+	python -m py_compile ./curator.py
+	python ./curator_test.py

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 
 test:
-	python --version
+	python3 --version
 	pip install elasticsearch freezegun
 	# Syntax check
-	python -m py_compile ./curator.py
-	python ./curator_test.py
+	python3 -m py_compile ./curator.py
+	python3 ./curator_test.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
 
 test:
+	python --version
 	pip install elasticsearch freezegun
 	# Syntax check
-	python3 -m py_compile ./curator.py
-	python3 ./curator_test.py
+	python -m py_compile ./curator.py
+	python ./curator_test.py

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,6 @@
 
 test:
 	pip install elasticsearch freezegun
-	python ./curator_test.py
+	# Syntax check
+	python3 -m py_compile ./curator.py
+	python3 ./curator_test.py

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ The following environment variables can be used for configuration:
 
 - `ELASTICSEARCH_HOST`: Name of the host that's running elasticsearch (default: `elasticsearch:9200`)
 - `RETENTION_DAYS`: Number of days to keep indices for (default: `14`)
-- `INDEX_NAME_PREFIX`: Name prefix of the temporal index (default: `fluentd-`)
+- `INDEX_NAME_PREFIX`: Name prefix of the temporal index (default: `fluentd-`). This can also be a space-separated list of names, which means that there are several indexes per temporal unit.
 - `INDEX_NAME_TIMEFORMAT`: Temporal string format in the index name (default: `%Y.%m.%d`)


### PR DESCRIPTION
For https://github.com/giantswarm/g8s-efk/issues/32

This changes the curator configuration so that curator can work on a list of index patterns, as opposed to only one index pattern. This will allow to let curator remove old indices with several names, as will be the case during the naming transition period.

The change is much smaller than it appears from looking at the diff.