### PR TITLE
Fix global/local variable modification bug

### DIFF
--- a/curator.py
+++ b/curator.py
@@ -41,6 +41,10 @@ def get_valid_indices(nameprefix, retention_days, timeformat):
 
 
 def main():
+    global index_name_prefix
+    global retention_days
+    global index_name_timeformat
+    global elasticsearch_host
 
     # Initial validation
 

--- a/curator.py
+++ b/curator.py
@@ -10,7 +10,7 @@ import sys
 # read environment variables
 elasticsearch_host = os.getenv("ELASTICSEARCH_HOST", "elasticsearch:9200")
 retention_days = int(os.getenv("RETENTION_DAYS", "14"))
-index_name_prefix = os.getenv("INDEX_NAME_PREFIX", "fluentd-")
+index_name_prefix = os.getenv("INDEX_NAME_PREFIX", "fluentd- gslogs-")
 index_name_timeformat = os.getenv("INDEX_NAME_TIMEFORMAT", "%Y.%m.%d")
 
 


### PR DESCRIPTION
In the last PR, I changed the code to overwrite `index_name_prefix` in the `main()` function. That is only allowed for a local variable OR a global variable that is explicitly imported into the local scope.